### PR TITLE
Consider resource new if it isn't mounted

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,10 +15,8 @@ script:
 before_install:
   - openssl aes-256-cbc -K $encrypted_ca75a4df0e44_key -iv $encrypted_ca75a4df0e44_iv -in .travis/supermarket.pem.enc -out .travis/supermarket.pem -d
 deploy:
-  provider: chef-supermarket
-  user_id: mkulka
-  client_key: .travis/supermarket.pem
-  cookbook_category: Others
+  provider: script
+  script: bundle exec knife supermarket share efs -o .. --config-option user=mkulka --config-option client_key=.travis/supermarket.pem
   skip_cleanup: true
   on:
     tags: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # efs CHANGELOG
 
+## 1.0.1
+- [mattlqx] - Fix resource not converging if fstab line exists but not mounted.
+
+## 1.0.0
+- [mattlqx] - Moved implementation to library, wrappered by resource and recipe.
+
 ## 0.1.5
 - [mattlqx] - Gate more metadata for older Chef 11 delivery.
 

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'matt@lqx.net'
 license          'MIT'
 description      'Installs/Configures Amazon Elastic Filesystem mounts'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '1.0.0'
+version          '1.0.1'
 
 source_url 'https://github.com/mattlqx/cookbook-efs' if respond_to?(:source_url)
 issues_url 'https://github.com/mattlqx/cookbook-efs/issues' if respond_to?(:issues_url)

--- a/resources/mount_efs.rb
+++ b/resources/mount_efs.rb
@@ -18,7 +18,7 @@ property :options, String, desired_state: false
 
 load_current_value do |new_resource|
   @mount = EFS::Mount.new(new_resource.mount_point, new_resource.fsid, region_value)
-  if @mount.exists?
+  if @mount.exists? && @mount.mounted?
     @mount.load_existing_options
   else
     current_value_does_not_exist!

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,7 +4,7 @@ require 'chefspec/berkshelf'
 
 RSpec.configure do |config|
   # Specify the Chef log_level (default: :warn)
-  config.log_level = :debug
+  config.log_level = :warn
 
   # Specify the operating platform to mock Ohai data from (default: nil)
   config.platform = 'ubuntu'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,7 +4,7 @@ require 'chefspec/berkshelf'
 
 RSpec.configure do |config|
   # Specify the Chef log_level (default: :warn)
-  config.log_level = :warn
+  config.log_level = :debug
 
   # Specify the operating platform to mock Ohai data from (default: nil)
   config.platform = 'ubuntu'


### PR DESCRIPTION
I've encountered the situation where a mount wasn't mounted but in the fstab that the cookbook will not apply the resource because its considered unchanged from the previous run. By adding `mounted?` into the load_current_value if, it should run all the resources if its unmounted.